### PR TITLE
Added handling of copystatus invalid.

### DIFF
--- a/media-functions-for-logic-app/functions/check-blob-copy-to-container-status.cs
+++ b/media-functions-for-logic-app/functions/check-blob-copy-to-container-status.cs
@@ -84,7 +84,7 @@ namespace media_functions_for_logic_app
                 foreach (var dest in destBlobList)
                 {
                     var destBlob = dest as CloudBlob;
-                    if (destBlob.CopyState.Status == CopyStatus.Aborted || destBlob.CopyState.Status == CopyStatus.Failed)
+                    if (destBlob.CopyState.Status == CopyStatus.Aborted || destBlob.CopyState.Status == CopyStatus.Failed || destBlob.CopyState.Status == CopyStatus.Invalid)
                     {
                         // Log the copy status description for diagnostics and restart copy
                         destBlob.StartCopyAsync(destBlob.CopyState.Source);


### PR DESCRIPTION
There are five statuses defined in copystatus.
  - Invalid, Pending, Success, Aborted, Failed
https://docs.microsoft.com/en-us/dotnet/api/microsoft.windowsazure.storage.blob.copystatus?view=azure-dotnet

In this code, invalid is not handled. 
Although it is a simple correspondence, I will propose addition.